### PR TITLE
Pre-push script changes

### DIFF
--- a/iOS-coverage-script/pre-push
+++ b/iOS-coverage-script/pre-push
@@ -17,6 +17,8 @@ fi
 
 if [ -f ${ROOT_DIR}/test ] ; then
   ${ROOT_DIR}/test;
+  git add ./${CODE_COVERAGE_FILE}
+  git commit --amend --no-edit
 else
   exit 1
 fi


### PR DESCRIPTION
### Summary
Add amend to code_coverage.json on pre-push to avoid a second push with the changes.